### PR TITLE
Update process of release notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,17 @@ jobs:
         run: npm publish build/ --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_DASCHBOT}}
-      - uses: lakto/gren-action@v1.1.0
+      - if: "github.event.release.prerelease"
+        name: Update release notes
+        uses: lakto/gren-action@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          options: '--override --prerelease'
+      - if: "!github.event.release.prerelease"
+        name: Update release notes
+        uses: lakto/gren-action@v2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          options: '--override'


### PR DESCRIPTION
This PR splits the Gren workflow step into two variations: one runs on prerelease with the `--prerelease` option and one on release without this parameter.
The options parameter is a new feature of the latest release of [lakto/gren-action](https://github.com/lakto/gren-action/tree/v2.0.0)