### PR TITLE
DSP-1138 Add missing guiOrder to serialize IHasProperty

### DIFF
--- a/src/models/v2/custom-converters/has-cardinality-for-property-converter.ts
+++ b/src/models/v2/custom-converters/has-cardinality-for-property-converter.ts
@@ -34,6 +34,10 @@ export class HasCardinalityForPropertyConverter implements JsonCustomConvert<IHa
                 } else {
                     throw new Error("Invalid cardinality: " + card.cardinality);
                 }
+                
+                if (card.guiOrder) {
+                    cardEle[Constants.GuiOrder] = card.guiOrder;
+                }
 
                 const cardObj: { [index: string]: string | object } = {
                     "@id": card.resourceClass as string,


### PR DESCRIPTION
resolves DSP-1138

For the reviewers. You can have a look in the updated file in `deserialize` that there we have `guiOrder` definition but it was missing in `serialize`
