### PR TITLE
feat(endpoint): Retry failed HTTP requests (DSP-170)

### DIFF
--- a/src/api/endpoint.ts
+++ b/src/api/endpoint.ts
@@ -25,19 +25,6 @@ export interface IHeaderOptions {
  */
 export class Endpoint {
 
-    ///////////////
-    // CONSTANTS //
-    ///////////////
-
-    // <editor-fold desc="">
-    // </editor-fold>
-
-    ////////////////
-    // PROPERTIES //
-    ////////////////
-
-    // <editor-fold desc="">
-
     readonly maxRetries = 5;
 
     readonly delay = 500;
@@ -68,28 +55,11 @@ export class Endpoint {
         this.knoraApiConfig.jsonWebToken = value;
     }
 
-    // </editor-fold>
-
-    /////////////////
-    // CONSTRUCTOR //
-    /////////////////
-
-    // <editor-fold desc="">
-
     /**
      * Constructor.
      */
     constructor(protected readonly knoraApiConfig: KnoraApiConfig, protected readonly path: string) {
     }
-
-    // </editor-fold>
-
-    /////////////
-    // METHODS //
-    /////////////
-
-    // <editor-fold desc="">
-    // </editor-fold>
 
     /**
      * Performs a general GET request.
@@ -120,7 +90,10 @@ export class Endpoint {
 
         if (path === undefined) path = "";
 
-        return ajax.post(this.knoraApiConfig.apiUrl + this.path + path, body, this.constructHeader(contentType, headerOpts));
+        return ajax.post(this.knoraApiConfig.apiUrl + this.path + path, body, this.constructHeader(contentType, headerOpts))
+            .pipe(
+                retryOnError(this.delay, this.maxRetries, this.retryOnErrorStatus, this.knoraApiConfig.logErrors)
+            );
 
     }
 
@@ -136,7 +109,10 @@ export class Endpoint {
 
         if (path === undefined) path = "";
 
-        return ajax.put(this.knoraApiConfig.apiUrl + this.path + path, body, this.constructHeader(contentType, headerOpts));
+        return ajax.put(this.knoraApiConfig.apiUrl + this.path + path, body, this.constructHeader(contentType, headerOpts))
+            .pipe(
+                retryOnError(this.delay, this.maxRetries, this.retryOnErrorStatus, this.knoraApiConfig.logErrors)
+            );
 
     }
 
@@ -152,7 +128,10 @@ export class Endpoint {
 
         if (path === undefined) path = "";
 
-        return ajax.patch(this.knoraApiConfig.apiUrl + this.path + path, body, this.constructHeader(contentType, headerOpts));
+        return ajax.patch(this.knoraApiConfig.apiUrl + this.path + path, body, this.constructHeader(contentType, headerOpts))
+            .pipe(
+                retryOnError(this.delay, this.maxRetries, this.retryOnErrorStatus, this.knoraApiConfig.logErrors)
+            );
 
     }
 
@@ -166,7 +145,10 @@ export class Endpoint {
 
         if (path === undefined) path = "";
 
-        return ajax.delete(this.knoraApiConfig.apiUrl + this.path + path, this.constructHeader(undefined, headerOpts));
+        return ajax.delete(this.knoraApiConfig.apiUrl + this.path + path, this.constructHeader(undefined, headerOpts))
+            .pipe(
+                retryOnError(this.delay, this.maxRetries, this.retryOnErrorStatus, this.knoraApiConfig.logErrors)
+            );
 
     }
 

--- a/src/api/operators/retryOnError.spec.ts
+++ b/src/api/operators/retryOnError.spec.ts
@@ -1,0 +1,41 @@
+import { of } from "rxjs";
+import { switchMap } from "rxjs/operators";
+import { TestScheduler } from "rxjs/testing";
+import { retryOnError } from "./retryOnError";
+import createSpy = jasmine.createSpy;
+
+describe("RetryOnError Operator", () => {
+    let scheduler: TestScheduler;
+
+    beforeEach(() => {
+        scheduler = new TestScheduler((actual, expected) => {
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    it("Retry try on error", () => {
+        scheduler.run(({cold, expectObservable}) => {
+
+            const values = {a: 20};
+
+            const ajaxError = {status: 0};
+
+            const send = createSpy("send");
+            send.and.returnValues(cold("-#", undefined, ajaxError), cold("-#", undefined, ajaxError), cold("-a", values));
+
+            const source$ = of(undefined).pipe(
+                switchMap(() => send())
+            );
+
+            const expectedMarble = "-----a";
+            const expectedValues = {a: 20};
+
+            const result$ = source$.pipe(
+                retryOnError(1, 5, [0], true)
+            );
+            expectObservable(result$).toBe(expectedMarble, expectedValues);
+
+        });
+    });
+
+});

--- a/src/api/operators/retryOnError.spec.ts
+++ b/src/api/operators/retryOnError.spec.ts
@@ -91,4 +91,25 @@ describe("RetryOnError Operator", () => {
         });
     });
 
+    it("should not retry on certain error status", () => {
+        scheduler.run(({cold, expectObservable}) => {
+
+            const ajaxError = { status: 400 };
+
+            const source$ = createRetryableStream(
+                cold("#", undefined, ajaxError),
+                cold("#", undefined, ajaxError)
+            );
+
+            const expectedMarble = "#";
+
+            const result$ = source$.pipe(
+                retryOnError(1, 1, [0], true)
+            );
+
+            expectObservable(result$).toBe(expectedMarble, undefined, ajaxError);
+
+        });
+    });
+
 });

--- a/src/api/operators/retryOnError.spec.ts
+++ b/src/api/operators/retryOnError.spec.ts
@@ -13,21 +13,27 @@ describe("RetryOnError Operator", () => {
         });
     });
 
-    it("Retry try on error", () => {
+    it("should get a completed response after 3 unsuccessful requests", () => {
         scheduler.run(({cold, expectObservable}) => {
 
             const values = {a: 20};
 
             const ajaxError = {status: 0};
 
-            const send = createSpy("send");
-            send.and.returnValues(cold("-#", undefined, ajaxError), cold("-#", undefined, ajaxError), cold("-a", values));
-
-            const source$ = of(undefined).pipe(
-                switchMap(() => send())
+            // https://stackoverflow.com/questions/57406445/rxjs-marble-testing-retrywhen
+            const http = createSpy("http");
+            http.and.returnValues(
+                cold("-#", undefined, ajaxError),
+                cold("-#", undefined, ajaxError),
+                cold("-#", undefined, ajaxError),
+                cold("-a|", values)
             );
 
-            const expectedMarble = "-----a";
+            const source$ = of(undefined).pipe(
+                switchMap(() => http())
+            );
+
+            const expectedMarble = "-------a|";
             const expectedValues = {a: 20};
 
             const result$ = source$.pipe(

--- a/src/api/operators/retryOnError.ts
+++ b/src/api/operators/retryOnError.ts
@@ -16,7 +16,8 @@ import { delay, mergeMap, retryWhen, tap } from "rxjs/operators";
 export function retryOnError(delayMs: number, maxRetries: number, retryOnErrorStatus: number[], logError: boolean) {
     let retries = maxRetries;
 
-    return (src: Observable<any>) =>
+    // inspired by https://medium.com/angular-in-depth/retry-failed-http-requests-in-angular-f5959d486294
+    return (src: Observable<AjaxResponse>) =>
         src.pipe(
             retryWhen(errors =>
                 errors.pipe(
@@ -26,7 +27,7 @@ export function retryOnError(delayMs: number, maxRetries: number, retryOnErrorSt
                     }),
                     mergeMap((error: AjaxError) => {
                         // retry on specified error status
-                        // check if max retries is reached
+                        // check if max retries is reached ("retries" is decremented on each retry)
                         if (retryOnErrorStatus.indexOf(error.status) !== -1 && retries-- > 0) {
                             return of(error).pipe(
                                 // delay retry

--- a/src/api/operators/retryOnError.ts
+++ b/src/api/operators/retryOnError.ts
@@ -17,8 +17,9 @@ export function retryOnError(delayMs: number, maxRetries: number, retryOnErrorSt
     let retries = maxRetries;
 
     // inspired by https://medium.com/angular-in-depth/retry-failed-http-requests-in-angular-f5959d486294
-    return (src: Observable<AjaxResponse>) =>
+    return (src: Observable<AjaxResponse>): Observable<AjaxResponse> =>
         src.pipe(
+            // when no error is thrown, this simply returns the source Observable
             retryWhen(errors =>
                 errors.pipe(
                     // log error message if logging is enabled

--- a/src/api/operators/retryOnError.ts
+++ b/src/api/operators/retryOnError.ts
@@ -16,16 +16,15 @@ import { delay, mergeMap, retryWhen, tap } from "rxjs/operators";
 export function retryOnError(delayMs: number, maxRetries: number, retryOnErrorStatus: number[], logError: boolean) {
     let retries = maxRetries;
 
-    return (src: Observable<AjaxResponse>) =>
+    return (src: Observable<any>) =>
         src.pipe(
             retryWhen(errors =>
                 errors.pipe(
                     delay(delayMs),
                     // log error message
                     tap((error: AjaxError) => {
-                        if (logError) console.error("HTTP request failed", error);
+                        if (logError) console.error("HTTP request failed", error.status);
                     }),
                     mergeMap((error: AjaxError) => retryOnErrorStatus.indexOf(error.status) !== -1 && --retries > 0 ? of(error) : throwError(error))
                 )));
-
 }

--- a/src/api/operators/retryOnError.ts
+++ b/src/api/operators/retryOnError.ts
@@ -1,0 +1,31 @@
+import { Observable, of, throwError } from "rxjs";
+import { AjaxError, AjaxResponse } from "rxjs/ajax";
+import { delay, mergeMap, retryWhen, tap } from "rxjs/operators";
+
+/**
+ *
+ * Retries failed HTTP requests.
+ *
+ * @param delayMs delay in milliseconds before the request is retried.
+ * @param maxRetries maximum number of retries.
+ * @param retryOnErrorStatus HTTP error status codes for which the request is retried.
+ * @param logError if true, error is written to the console error log.
+ *
+ * @category Internal
+ */
+export function retryOnError(delayMs: number, maxRetries: number, retryOnErrorStatus: number[], logError: boolean) {
+    let retries = maxRetries;
+
+    return (src: Observable<AjaxResponse>) =>
+        src.pipe(
+            retryWhen(errors =>
+                errors.pipe(
+                    delay(delayMs),
+                    // log error message
+                    tap((error: AjaxError) => {
+                        if (logError) console.error("HTTP request failed", error);
+                    }),
+                    mergeMap((error: AjaxError) => retryOnErrorStatus.indexOf(error.status) !== -1 && --retries > 0 ? of(error) : throwError(error))
+                )));
+
+}

--- a/src/api/operators/retryOnError.ts
+++ b/src/api/operators/retryOnError.ts
@@ -20,16 +20,20 @@ export function retryOnError(delayMs: number, maxRetries: number, retryOnErrorSt
         src.pipe(
             retryWhen(errors =>
                 errors.pipe(
-                    // log error message
+                    // log error message if logging is enabled
                     tap((error: AjaxError) => {
-                        if (logError) console.error("HTTP request failed", error.status);
+                        if (logError) console.error("HTTP request failed", error.status, retries);
                     }),
                     mergeMap((error: AjaxError) => {
+                        // retry on specified error status
+                        // check if max retries is reached
                         if (retryOnErrorStatus.indexOf(error.status) !== -1 && retries-- > 0) {
                             return of(error).pipe(
+                                // delay retry
                                 delay(delayMs)
                             );
                         } else {
+                            // do not retry
                             return throwError(error);
                         }
                     })

--- a/src/api/operators/retryOnError.ts
+++ b/src/api/operators/retryOnError.ts
@@ -22,7 +22,7 @@ export function retryOnError(delayMs: number, maxRetries: number, retryOnErrorSt
                 errors.pipe(
                     // log error message if logging is enabled
                     tap((error: AjaxError) => {
-                        if (logError) console.error("HTTP request failed", error.status, retries);
+                        if (logError) console.error("HTTP request failed:", "status:", error.status, "retries:", retries, "error:", error);
                     }),
                     mergeMap((error: AjaxError) => {
                         // retry on specified error status


### PR DESCRIPTION
resolves DSP-170

This PR introduces a custom RxJS operator called `retryOnError` (inspired by https://medium.com/angular-in-depth/retry-failed-http-requests-in-angular-f5959d486294).

The operator retries failed HTTP request for specified error status codes. If the error is the user's fault (malformed query etc.), no retry should be performed. Retries should happen when the network is unstable ([XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) [status 0](https://stackoverflow.com/questions/47424413/rxjs-5-how-to-get-statuscode-on-catch)):

![retry](https://user-images.githubusercontent.com/6000023/103995440-c6602280-5198-11eb-8eec-054ae32c61e7.gif)

